### PR TITLE
Update CoinCap base URL and add Docker tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Welcome to **CoinCap Foreign Data Wrapper (FDW)**. This project exposes cryptocu
 
 ## What the project does
 
-CoinCap FDW lets you create a PostgreSQL foreign table that proxies a CoinCap API endpoint (by default `https://api.coincap.io/v2/assets`). Queries against this table trigger HTTP requests to fetch the data and return the JSON fields matching the table columns. The wrapper is read‐only and meant as a simple reference implementation for FDW development.
+CoinCap FDW lets you create a PostgreSQL foreign table that proxies a CoinCap API endpoint (by default `https://rest.coincap.io/v3/assets`). Queries against this table trigger HTTP requests to fetch the data and return the JSON fields matching the table columns. The wrapper is read‐only and meant as a simple reference implementation for FDW development.
 
 Key components:
 
@@ -24,8 +24,9 @@ Key components:
    CREATE SERVER coincap
        FOREIGN DATA WRAPPER multicorn
        OPTIONS (wrapper 'coincap_fdw.CoinCapForeignDataWrapper',
-                base_url 'https://api.coincap.io/v2',
-                endpoint 'assets');
+                base_url 'https://rest.coincap.io/v3',
+                endpoint 'assets',
+                api_key '<your API key>');
    ```
    The `base_url` and `endpoint` options are configurable when you create the server.
 3. Create a foreign table describing the columns you want to expose and query it like a normal table. Each query fetches from the configured CoinCap endpoint.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM postgres:15
+
+ENV POSTGRES_PASSWORD=postgres
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_DB=postgres
+
+RUN apt-get update && apt-get install -y python3-pip python3-dev build-essential libpq-dev postgresql-server-dev-all git \
+    && pip3 install multicorn hy && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+RUN pip3 install /src
+
+# Use the default command from postgres image
+

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ CREATE EXTENSION multicorn;
 CREATE SERVER coincap
     FOREIGN DATA WRAPPER multicorn
     OPTIONS (wrapper 'coincap_fdw.CoinCapForeignDataWrapper',
-            base_url 'https://api.coincap.io/v2',
-            endpoint 'assets');
+            base_url 'https://rest.coincap.io/v3',
+            endpoint 'assets',
+            api_key '<your API key>');
 These options allow querying different CoinCap endpoints without changing the wrapper.
-The defaults are base_url "https://api.coincap.io/v2" and endpoint "assets".
+The defaults are base_url "https://rest.coincap.io/v3" and endpoint "assets".
+An API key is required by CoinCap and can be provided with the `api_key` option.
 
 -- define a foreign table using the server
 CREATE FOREIGN TABLE crypto_assets (

--- a/coincap_fdw/api.py
+++ b/coincap_fdw/api.py
@@ -1,12 +1,15 @@
 import json
 import requests
 
-DEFAULT_BASE_URL = "https://api.coincap.io/v2"
+DEFAULT_BASE_URL = "https://rest.coincap.io/v3"
 
 
-def fetch_endpoint(endpoint: str, base_url: str = DEFAULT_BASE_URL):
+def fetch_endpoint(endpoint: str, base_url: str = DEFAULT_BASE_URL, api_key: str | None = None):
     """Fetch JSON data from the given CoinCap API endpoint."""
     url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+    if api_key:
+        sep = "?" if "?" not in url else "&"
+        url = f"{url}{sep}apiKey={api_key}"
     resp = requests.request("GET", url)
     resp.raise_for_status()
     return json.loads(resp.content.decode("utf-8"))["data"]

--- a/coincap_fdw/wrapper.hy
+++ b/coincap_fdw/wrapper.hy
@@ -10,9 +10,10 @@
     (-> (super CoinCapForeignDataWrapper self) (.--init-- options columns))
     (setv self.columns columns)
     (setv self.base-url (get options "base_url" DEFAULT_BASE_URL))
-    (setv self.endpoint (get options "endpoint" "assets")))
+    (setv self.endpoint (get options "endpoint" "assets"))
+    (setv self.api-key (get options "api_key" None)))
 
   (defn execute [self quals columns]
-    (setv assets-list (fetch_endpoint self.endpoint self.base-url))
+    (setv assets-list (fetch_endpoint self.endpoint self.base-url self.api-key))
     (lfor asset assets-list (dict-filter asset self.columns)))
 

--- a/coincap_fdw/wrapper.py
+++ b/coincap_fdw/wrapper.py
@@ -13,8 +13,9 @@ class CoinCapForeignDataWrapper(ForeignDataWrapper):
         self.columns = columns
         self.base_url = options.get("base_url", DEFAULT_BASE_URL)
         self.endpoint = options.get("endpoint", "assets")
+        self.api_key = options.get("api_key")
 
     def execute(self, quals, columns):
-        assets_list = fetch_endpoint(self.endpoint, self.base_url)
+        assets_list = fetch_endpoint(self.endpoint, self.base_url, self.api_key)
         return [dict_filter(asset, self.columns) for asset in assets_list]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.25.1
 
 hy==0.20.0
+psycopg2-binary

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -1,0 +1,70 @@
+import os
+import shutil
+import subprocess
+import time
+import unittest
+
+try:
+    import psycopg2
+except Exception:  # pragma: no cover - dependency missing
+    psycopg2 = None
+
+
+class TestDockerPostgres(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if psycopg2 is None:
+            raise unittest.SkipTest("psycopg2 not installed")
+        if not shutil.which('docker'):
+            raise unittest.SkipTest('docker not available')
+        if 'COINCAP_TOKEN' not in os.environ:
+            raise unittest.SkipTest('COINCAP_TOKEN not set')
+
+        subprocess.run(['docker', 'build', '-t', 'coincap_fdw_test', '.'], check=True)
+        cls.proc = subprocess.Popen(
+            ['docker', 'run', '--rm', '-e', 'POSTGRES_PASSWORD=postgres', '-p', '55432:5432', 'coincap_fdw_test'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        for _ in range(30):
+            try:
+                conn = psycopg2.connect(host='localhost', port=55432, user='postgres', password='postgres', dbname='postgres')
+                conn.close()
+                break
+            except Exception:
+                time.sleep(1)
+        else:
+            cls.proc.terminate()
+            cls.proc.wait()
+            raise RuntimeError('postgres did not start')
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, 'proc'):
+            cls.proc.terminate()
+            cls.proc.wait()
+
+    def test_query(self):
+        token = os.environ['COINCAP_TOKEN']
+        conn = psycopg2.connect(host='localhost', port=55432, user='postgres', password='postgres', dbname='postgres')
+        cur = conn.cursor()
+        cur.execute('CREATE EXTENSION multicorn;')
+        cur.execute("""
+            CREATE SERVER coincap FOREIGN DATA WRAPPER multicorn OPTIONS (
+                wrapper 'coincap_fdw.CoinCapForeignDataWrapper',
+                api_key '%s'
+            );
+        """ % token)
+        cur.execute("""
+            CREATE FOREIGN TABLE assets (
+                id text,
+                name text
+            ) SERVER coincap;
+        """)
+        cur.execute('SELECT id FROM assets LIMIT 1;')
+        row = cur.fetchone()
+        self.assertIsNotNone(row)
+        conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -42,6 +42,13 @@ class TestAPI(unittest.TestCase):
         with patch('requests.request', make_mock_request(url, data)):
             self.assertEqual(fetch_endpoint('assets'), data)
 
+    def test_fetch_endpoint_with_api_key(self):
+        data = [{'id': 'btc'}]
+        key = 'secret'
+        url = f"{DEFAULT_BASE_URL}/assets?apiKey={key}"
+        with patch('requests.request', make_mock_request(url, data)):
+            self.assertEqual(fetch_endpoint('assets', api_key=key), data)
+
     def test_fetch_endpoint_error(self):
         class BadResponse(DummyResponse):
             def raise_for_status(self):
@@ -61,6 +68,15 @@ class TestWrapper(unittest.TestCase):
         url = f"{DEFAULT_BASE_URL}/assets"
         with patch('requests.request', make_mock_request(url, data)):
             wrapper = CoinCapForeignDataWrapper({}, {'id': {}})
+            rows = list(wrapper.execute({}, {}))
+            self.assertEqual(rows, [{'id': 'btc'}])
+
+    def test_execute_with_api_key(self):
+        data = [{'id': 'btc'}]
+        key = 'secret'
+        url = f"{DEFAULT_BASE_URL}/assets?apiKey={key}"
+        with patch('requests.request', make_mock_request(url, data)):
+            wrapper = CoinCapForeignDataWrapper({'api_key': key}, {'id': {}})
             rows = list(wrapper.execute({}, {}))
             self.assertEqual(rows, [{'id': 'btc'}])
 


### PR DESCRIPTION
## Summary
- migrate default CoinCap endpoint to REST API v3
- pass optional `api_key` to requests
- document new API base URL and key requirement
- add Dockerfile for Postgres with the wrapper installed
- add integration test using Docker (skipped without psycopg2 or Docker)

## Testing
- `python -m unittest discover -s tests -v`